### PR TITLE
ability to persist timer state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
 	"name": "svelte-timer-store",
-	"version": "0.1.0",
+	"version": "0.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "svelte-timer-store",
-			"version": "0.1.0",
+			"version": "0.3.0",
 			"license": "MIT",
+			"dependencies": {
+				"svelte-local-storage-store": "^0.4.0"
+			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^1.0.0",
 				"@sveltejs/kit": "^1.0.0",
@@ -2774,6 +2777,17 @@
 				"svelte": ">=3.19.0"
 			}
 		},
+		"node_modules/svelte-local-storage-store": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/svelte-local-storage-store/-/svelte-local-storage-store-0.4.0.tgz",
+			"integrity": "sha512-ctPykTt4S3BE5bF0mfV0jKiUR1qlmqLvnAkQvYHLeb9wRyO1MdIFDVI23X+TZEFleATHkTaOpYZswIvf3b2tWA==",
+			"engines": {
+				"node": ">=0.14"
+			},
+			"peerDependencies": {
+				"svelte": "^3.48.0"
+			}
+		},
 		"node_modules/svelte-preprocess": {
 			"version": "4.10.7",
 			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
@@ -5043,6 +5057,12 @@
 			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.1.tgz",
 			"integrity": "sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==",
 			"dev": true,
+			"requires": {}
+		},
+		"svelte-local-storage-store": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/svelte-local-storage-store/-/svelte-local-storage-store-0.4.0.tgz",
+			"integrity": "sha512-ctPykTt4S3BE5bF0mfV0jKiUR1qlmqLvnAkQvYHLeb9wRyO1MdIFDVI23X+TZEFleATHkTaOpYZswIvf3b2tWA==",
 			"requires": {}
 		},
 		"svelte-preprocess": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "svelte-timer-store",
 	"description": "Simple timer store with support for pausing and laps",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"license": "MIT",
 	"author": "Matias Kumpulainen <matias.kumpulainen@kvanttori.fi>",
 	"repository": "kumpmati/svelte-timer-store",
@@ -40,5 +40,8 @@
 	"peerDependencies": {
 		"svelte": "^3.59.1"
 	},
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"svelte-local-storage-store": "^0.4.0"
+	}
 }

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -12,6 +12,23 @@ export type TimerOptions = {
 	 * Default: `16`
 	 */
 	updateInterval?: number;
+
+	/**
+	 * Persists the timer state into local or session storage.
+	 */
+	persist?: {
+		/**
+		 * ID to use when saving / loading the timer.
+		 */
+		id: string | number;
+
+		/**
+		 * Where to save the state
+		 *
+		 * Default: `local`
+		 */
+		strategy: 'local' | 'session';
+	};
 };
 
 export type Timer = Readable<TimerState> & {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
 	import { createTimer } from '$lib';
 
-	const timer = createTimer({ showMs: true });
+	const timer = createTimer({
+		showMs: true,
+		persist: {
+			id: '1',
+			strategy: 'local'
+		}
+	});
 </script>
 
 <h1>durationString: {$timer.durationStr}</h1>


### PR DESCRIPTION
User can choose to persist the timer state into local/session storage. Uses `svelte-local-storage-store` internally.

closes #9 