### PR TITLE
update svelte dependency requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "svelte-timer-store",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "svelte-timer-store",
-			"version": "0.6.0",
+			"version": "0.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"svelte-local-storage-store": "^0.4.0"
@@ -29,7 +29,7 @@
 				"vitest": "^0.25.3"
 			},
 			"peerDependencies": {
-				"svelte": "^3.59.1"
+				"svelte": ">=3.59.1"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "svelte-timer-store",
 	"description": "Simple timer store with support for pausing and laps",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"license": "MIT",
 	"author": "Matias Kumpulainen <matias.kumpulainen@kvanttori.fi>",
 	"repository": "kumpmati/svelte-timer-store",
@@ -38,7 +38,7 @@
 		"vitest": "^0.25.3"
 	},
 	"peerDependencies": {
-		"svelte": "^3.59.1"
+		"svelte": ">=3.59.1"
 	},
 	"type": "module",
 	"dependencies": {


### PR DESCRIPTION
set to `>=3.59.1` so that it's possible to use with svelte 4 as well